### PR TITLE
docs: remove __main__.py reference from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ my-server/
 └── src/
     └── my_server/
         ├── __init__.py
-        ├── __main__.py
         └── server.py
 ```
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Remove outdated reference to `src/__main__.py` from README

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The template no longer generates `src/__main__.py`, but this wasn't reflected in the README. This update ensures documentation matches actual template output.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Verified README changes match current template structure.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None. Documentation-only change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
None.
